### PR TITLE
Add tests and coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,7 @@ jobs:
           version: v2.1
       - name: Test
         run: go test ./... -coverprofile=coverage.out
-      - name: Upload coverage
-        uses: codecov/codecov-action@v4
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
         with:
-          files: coverage.out
-          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,4 +29,9 @@ jobs:
         with:
           version: v2.1
       - name: Test
-        run: go test ./... -cover
+        run: go test ./... -coverprofile=coverage.out
+      - name: Upload coverage
+        uses: codecov/codecov-action@v4
+        with:
+          files: coverage.out
+          fail_ci_if_error: true

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Go CI](https://github.com/omarfawzi/API-Gateway/actions/workflows/ci.yml/badge.svg)](https://github.com/omarfawzi/API-Gateway/actions/workflows/ci.yml)
 [![Docker Build](https://github.com/omarfawzi/API-Gateway/actions/workflows/docker.yml/badge.svg)](https://github.com/omarfawzi/API-Gateway/actions/workflows/docker.yml)
+[![Codecov](https://codecov.io/gh/omarfawzi/API-Gateway/branch/main/graph/badge.svg)](https://codecov.io/gh/omarfawzi/API-Gateway)
 
 API Gateway is a high-performance, configurable API gateway built on top of [Lura (KrakenD)](https://github.com/luraproject/lura).
 

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -6,14 +6,20 @@ import (
 )
 
 func TestLoadDefaults(t *testing.T) {
-	os.Unsetenv("APP_CLUSTER")
-	os.Unsetenv("APP_ENVIRONMENT")
-	os.Unsetenv("APP_PORT")
-	os.Unsetenv("LOGGER_LEVEL")
-	os.Unsetenv("LOGGER_ENABLE")
-	os.Unsetenv("SENTRY_ENABLE")
-	os.Unsetenv("SENTRY_DSN")
-	os.Unsetenv("SENTRY_DEBUG")
+	for _, key := range []string{
+		"APP_CLUSTER",
+		"APP_ENVIRONMENT",
+		"APP_PORT",
+		"LOGGER_LEVEL",
+		"LOGGER_ENABLE",
+		"SENTRY_ENABLE",
+		"SENTRY_DSN",
+		"SENTRY_DEBUG",
+	} {
+		if err := os.Unsetenv(key); err != nil {
+			t.Fatalf("failed to unset env var %s: %v", key, err)
+		}
+	}
 
 	cfg, err := Load()
 	if err != nil {

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -1,0 +1,88 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+func TestLoadDefaults(t *testing.T) {
+	os.Unsetenv("APP_CLUSTER")
+	os.Unsetenv("APP_ENVIRONMENT")
+	os.Unsetenv("APP_PORT")
+	os.Unsetenv("LOGGER_LEVEL")
+	os.Unsetenv("LOGGER_ENABLE")
+	os.Unsetenv("SENTRY_ENABLE")
+	os.Unsetenv("SENTRY_DSN")
+	os.Unsetenv("SENTRY_DEBUG")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Cluster != "dev" {
+		t.Errorf("expected default cluster 'dev', got %s", cfg.Cluster)
+	}
+	if cfg.Environment != "local" {
+		t.Errorf("expected default environment 'local', got %s", cfg.Environment)
+	}
+	if cfg.Port != 8080 {
+		t.Errorf("expected default port 8080, got %d", cfg.Port)
+	}
+	if cfg.Logger.Level != "INFO" {
+		t.Errorf("expected default logger level INFO, got %s", cfg.Logger.Level)
+	}
+	if cfg.Logger.Enable != false {
+		t.Errorf("expected default logger enable false, got %v", cfg.Logger.Enable)
+	}
+	if cfg.Sentry.Enable != false {
+		t.Errorf("expected default sentry enable false, got %v", cfg.Sentry.Enable)
+	}
+	if cfg.Sentry.Dsn != "" {
+		t.Errorf("expected default sentry dsn empty, got %s", cfg.Sentry.Dsn)
+	}
+	if cfg.Sentry.Debug != false {
+		t.Errorf("expected default sentry debug false, got %v", cfg.Sentry.Debug)
+	}
+}
+
+func TestLoadWithEnv(t *testing.T) {
+	t.Setenv("APP_CLUSTER", "prod")
+	t.Setenv("APP_ENVIRONMENT", "staging")
+	t.Setenv("APP_PORT", "9090")
+	t.Setenv("LOGGER_LEVEL", "DEBUG")
+	t.Setenv("LOGGER_ENABLE", "true")
+	t.Setenv("SENTRY_ENABLE", "true")
+	t.Setenv("SENTRY_DSN", "dsn")
+	t.Setenv("SENTRY_DEBUG", "true")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Cluster != "prod" {
+		t.Errorf("expected cluster 'prod', got %s", cfg.Cluster)
+	}
+	if cfg.Environment != "staging" {
+		t.Errorf("expected environment 'staging', got %s", cfg.Environment)
+	}
+	if cfg.Port != 9090 {
+		t.Errorf("expected port 9090, got %d", cfg.Port)
+	}
+	if cfg.Logger.Level != "DEBUG" {
+		t.Errorf("expected logger level DEBUG, got %s", cfg.Logger.Level)
+	}
+	if cfg.Logger.Enable != true {
+		t.Errorf("expected logger enable true, got %v", cfg.Logger.Enable)
+	}
+	if cfg.Sentry.Enable != true {
+		t.Errorf("expected sentry enable true, got %v", cfg.Sentry.Enable)
+	}
+	if cfg.Sentry.Dsn != "dsn" {
+		t.Errorf("expected sentry dsn 'dsn', got %s", cfg.Sentry.Dsn)
+	}
+	if cfg.Sentry.Debug != true {
+		t.Errorf("expected sentry debug true, got %v", cfg.Sentry.Debug)
+	}
+}

--- a/internal/errors/serverhandler_test.go
+++ b/internal/errors/serverhandler_test.go
@@ -1,0 +1,63 @@
+package errors
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestMiddlewareErrorResponse(t *testing.T) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Test", "value")
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("bad"))
+	})
+
+	handler, err := NewServerHandler().middleware(context.Background(), nil, next)
+	if err != nil {
+		t.Fatalf("middleware failed: %v", err)
+	}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/", nil)
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusInternalServerError {
+		t.Errorf("expected status %d got %d", http.StatusInternalServerError, rr.Code)
+	}
+	expected := "{\"errors\":{\"message\":\"Internal Server Error\"}}\n"
+	if rr.Body.String() != expected {
+		t.Errorf("unexpected body: %s", rr.Body.String())
+	}
+	if rr.Header().Get("X-Test") != "" {
+		t.Errorf("unexpected header forwarded")
+	}
+}
+
+func TestMiddlewareSuccess(t *testing.T) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Test", "ok")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("hello"))
+	})
+
+	handler, err := NewServerHandler().middleware(context.Background(), nil, next)
+	if err != nil {
+		t.Fatalf("middleware failed: %v", err)
+	}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/", nil)
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected status %d got %d", http.StatusOK, rr.Code)
+	}
+	if rr.Header().Get("X-Test") != "ok" {
+		t.Errorf("header not forwarded")
+	}
+	if rr.Body.String() != "hello" {
+		t.Errorf("body not forwarded: %s", rr.Body.String())
+	}
+}

--- a/internal/errors/serverhandler_test.go
+++ b/internal/errors/serverhandler_test.go
@@ -11,7 +11,10 @@ func TestMiddlewareErrorResponse(t *testing.T) {
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-Test", "value")
 		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte("bad"))
+		_, err := w.Write([]byte("bad"))
+		if err != nil {
+			return
+		}
 	})
 
 	handler, err := NewServerHandler().middleware(context.Background(), nil, next)
@@ -39,7 +42,10 @@ func TestMiddlewareSuccess(t *testing.T) {
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-Test", "ok")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("hello"))
+		_, err := w.Write([]byte("hello"))
+		if err != nil {
+			return
+		}
 	})
 
 	handler, err := NewServerHandler().middleware(context.Background(), nil, next)

--- a/internal/lura/clients/registry_test.go
+++ b/internal/lura/clients/registry_test.go
@@ -1,0 +1,33 @@
+package clients
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/luraproject/lura/v2/transport/http/client/plugin"
+)
+
+type fakeRegisterer struct{ called int }
+
+func (f *fakeRegisterer) RegisterClients(func(string, func(context.Context, map[string]interface{}) (http.Handler, error))) {
+	f.called++
+}
+
+func TestHandlerRegistry_RegisterHandlers(t *testing.T) {
+	r1 := &fakeRegisterer{}
+	r2 := &fakeRegisterer{}
+
+	registry := NewHandlerRegistry([]plugin.Registerer{r1, r2})
+	registry.RegisterHandlers()
+
+	if r1.called != 1 || r2.called != 1 {
+		t.Errorf("expected each registerer to be called once, got %d and %d", r1.called, r2.called)
+	}
+}
+
+func TestProvideHandlersEmpty(t *testing.T) {
+	if len(ProvideHandlers()) != 0 {
+		t.Errorf("expected empty handlers slice")
+	}
+}

--- a/internal/lura/proxy/registry_test.go
+++ b/internal/lura/proxy/registry_test.go
@@ -1,0 +1,31 @@
+package proxy
+
+import (
+	"testing"
+
+	"github.com/luraproject/lura/v2/proxy/plugin"
+)
+
+type fakeRegisterer struct{ called int }
+
+func (f *fakeRegisterer) RegisterModifiers(func(string, func(map[string]interface{}) func(interface{}) (interface{}, error), bool, bool)) {
+	f.called++
+}
+
+func TestHandlerRegistry_RegisterHandlers(t *testing.T) {
+	r1 := &fakeRegisterer{}
+	r2 := &fakeRegisterer{}
+
+	reg := NewHandlerRegistry([]plugin.Registerer{r1, r2})
+	reg.RegisterHandlers()
+
+	if r1.called != 1 || r2.called != 1 {
+		t.Errorf("expected each registerer to be called once, got %d and %d", r1.called, r2.called)
+	}
+}
+
+func TestProvideHandlersEmpty(t *testing.T) {
+	if len(ProvideHandlers()) != 0 {
+		t.Errorf("expected empty handlers slice")
+	}
+}

--- a/internal/wire_gen_test.go
+++ b/internal/wire_gen_test.go
@@ -1,0 +1,36 @@
+package internal
+
+import (
+	"reflect"
+	"testing"
+
+	"gateway/internal/config"
+)
+
+func TestProvideClientHandlerRegistry(t *testing.T) {
+	r, err := ProvideClientHandlerRegistry()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r == nil {
+		t.Fatal("nil registry returned")
+	}
+	handlers := reflect.ValueOf(r).Elem().FieldByName("handlers")
+	if handlers.Len() != 0 {
+		t.Errorf("expected no handlers, got %d", handlers.Len())
+	}
+}
+
+func TestProvideProxyHandlerRegistry(t *testing.T) {
+	r, err := ProvideProxyHandlerRegistry(&config.Config{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r == nil {
+		t.Fatal("nil registry returned")
+	}
+	handlers := reflect.ValueOf(r).Elem().FieldByName("handlers")
+	if handlers.Len() != 0 {
+		t.Errorf("expected no handlers, got %d", handlers.Len())
+	}
+}

--- a/utils/error_test.go
+++ b/utils/error_test.go
@@ -1,0 +1,49 @@
+package utils
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestWriteJSONError(t *testing.T) {
+	rr := httptest.NewRecorder()
+	WriteJSONError(rr, http.StatusNotFound)
+
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("expected status %d got %d", http.StatusNotFound, rr.Code)
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("unexpected content type %s", ct)
+	}
+
+	var resp ErrorResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if resp.Errors.Message != http.StatusText(http.StatusNotFound) {
+		t.Errorf("unexpected message %s", resp.Errors.Message)
+	}
+}
+
+func TestNewHTTPResponseError(t *testing.T) {
+	errObj := NewHTTPResponseError(http.StatusBadRequest)
+	if errObj.Code != http.StatusBadRequest {
+		t.Errorf("expected code %d got %d", http.StatusBadRequest, errObj.Code)
+	}
+	if errObj.Encoding() != "application/json" {
+		t.Errorf("unexpected encoding %s", errObj.Encoding())
+	}
+	if errObj.Msg == "" {
+		t.Errorf("expected message not empty")
+	}
+}
+
+func TestToJSONFallback(t *testing.T) {
+	ch := make(chan int)
+	out := toJSON(ch)
+	if out != "{}" {
+		t.Errorf("expected fallback '{}', got %s", out)
+	}
+}


### PR DESCRIPTION
## Summary
- add unit tests for config loader
- test error utils and server handler
- enable code coverage reporting via Codecov in CI
- display Codecov badge in README

## Testing
- `go vet ./...`
- `go test ./... -coverprofile=coverage.out`

------
https://chatgpt.com/codex/tasks/task_e_68442d1824248323b29ede0f9600e6f1