### PR TITLE
Add per-backend HTTP version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ git clone git@github.com:omarfawzi/API-Gateway.git
 - Debug and release modes
 - Integrated Sentry error tracking
 - gRPC backend support using declarative configuration
+- Per-path HTTP/1.x or HTTP/2 control via config
 
 
 ### Configuration
@@ -177,7 +178,11 @@ backend:
           scope: [request]
           name: X-Custom-Env
           value: {{ getenv "MY_ENV_TAG" | default "test-env" }}
+      backend/http/client:
+        version: "1"
 ```
+This forces HTTP/1.1 for that backend. Use `version: "2"` or omit the field to
+enable HTTP/2 when supported.
 
 > Gomplate is not used at runtime or during the application bootstrap. It runs only as an entrypoint in the container to generate the final configuration file.
 

--- a/config/api.yaml
+++ b/config/api.yaml
@@ -50,6 +50,9 @@ endpoints:
         url_pattern: /users
         method: GET
         encoding: no-op
+        extra_config:
+          backend/http/client:
+            version: "1"
 
   - endpoint: /comments
     method: GET

--- a/internal/lura/clients/httpclient.go
+++ b/internal/lura/clients/httpclient.go
@@ -1,0 +1,35 @@
+package clients
+
+import (
+	"crypto/tls"
+	"net/http"
+	"strings"
+
+	luraConfig "github.com/luraproject/lura/v2/config"
+)
+
+const httpVersionNamespace = "backend/http/client"
+
+func parseHTTPVersion(be *luraConfig.Backend) string {
+	raw, ok := be.ExtraConfig[httpVersionNamespace]
+	if !ok {
+		return "2"
+	}
+	m, ok := raw.(map[string]interface{})
+	if !ok {
+		return "2"
+	}
+	if v, ok := m["version"].(string); ok {
+		return v
+	}
+	return "2"
+}
+
+func newHTTPClient(version string) *http.Client {
+	tr := &http.Transport{ForceAttemptHTTP2: true}
+	if strings.HasPrefix(version, "1") {
+		tr.ForceAttemptHTTP2 = false
+		tr.TLSNextProto = map[string]func(string, *tls.Conn) http.RoundTripper{}
+	}
+	return &http.Client{Transport: tr}
+}

--- a/internal/lura/clients/provider.go
+++ b/internal/lura/clients/provider.go
@@ -1,6 +1,9 @@
 package clients
 
 import (
+	"context"
+	"net/http"
+
 	luraConfig "github.com/luraproject/lura/v2/config"
 	"github.com/luraproject/lura/v2/logging"
 	"github.com/luraproject/lura/v2/transport/http/client"
@@ -10,8 +13,11 @@ import (
 func ProvideHTTPRequestExecutor(
 	logger logging.Logger,
 ) func(*luraConfig.Backend) client.HTTPRequestExecutor {
-	return plugin.HTTPRequestExecutor(logger, func(*luraConfig.Backend) client.HTTPRequestExecutor {
-		return client.DefaultHTTPRequestExecutor(client.NewHTTPClient)
+	return plugin.HTTPRequestExecutor(logger, func(be *luraConfig.Backend) client.HTTPRequestExecutor {
+		version := parseHTTPVersion(be)
+		return client.DefaultHTTPRequestExecutor(func(context.Context) *http.Client {
+			return newHTTPClient(version)
+		})
 	})
 }
 

--- a/internal/lura/clients/provider_test.go
+++ b/internal/lura/clients/provider_test.go
@@ -1,0 +1,28 @@
+package clients
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestNewHTTPClient_HTTP1(t *testing.T) {
+	c := newHTTPClient("1")
+	tr, ok := c.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("expected transport")
+	}
+	if tr.ForceAttemptHTTP2 {
+		t.Errorf("expected http2 disabled")
+	}
+}
+
+func TestNewHTTPClient_HTTP2(t *testing.T) {
+	c := newHTTPClient("2")
+	tr, ok := c.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("expected transport")
+	}
+	if !tr.ForceAttemptHTTP2 {
+		t.Errorf("expected http2 enabled")
+	}
+}


### PR DESCRIPTION
## Summary
- allow selecting HTTP/1 or HTTP/2 per backend through `backend/http/client` config
- document HTTP version option and example usage
- update sample config to force HTTP/1 on `/users`
- test HTTP client creation for different versions
- **move HTTP version helpers into separate file**

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684bca4acdc08323a1ab171725a09f13