### PR TITLE
Add additional unit tests

### DIFF
--- a/internal/lura/clients/httpclient_test.go
+++ b/internal/lura/clients/httpclient_test.go
@@ -1,0 +1,20 @@
+package clients
+
+import (
+	luraConfig "github.com/luraproject/lura/v2/config"
+	"testing"
+)
+
+func TestParseHTTPVersion(t *testing.T) {
+	be := &luraConfig.Backend{ExtraConfig: map[string]interface{}{
+		httpVersionNamespace: map[string]interface{}{"version": "1.1"},
+	}}
+	if v := parseHTTPVersion(be); v != "1.1" {
+		t.Errorf("expected 1.1 got %s", v)
+	}
+
+	be = &luraConfig.Backend{}
+	if v := parseHTTPVersion(be); v != "2" {
+		t.Errorf("expected default 2 got %s", v)
+	}
+}

--- a/internal/lura/proxy/grpc/helper_test.go
+++ b/internal/lura/proxy/grpc/helper_test.go
@@ -1,0 +1,70 @@
+package grpc
+
+import (
+	"net/url"
+	"testing"
+
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func TestExtractHeaders(t *testing.T) {
+	headers := map[string][]string{"A": {"1"}, "B": {"2"}}
+	out := extractHeaders(headers, []string{"B"})
+	if out["B"] != "2" {
+		t.Errorf("expected B=2")
+	}
+}
+
+func TestExtractQueryParams(t *testing.T) {
+	q := url.Values{"A": {"1"}, "B": {"2"}}
+	out := extractQueryParams(q, []string{"A"})
+	if v := out["a"]; len(v) != 1 || v[0] != "1" {
+		t.Errorf("unexpected %v", out)
+	}
+}
+
+func TestDecodeRequestBody(t *testing.T) {
+	msg := &structpb.Struct{}
+	if err := decodeRequestBody([]byte(`{"foo":"bar"}`), msg); err != nil {
+		t.Fatal(err)
+	}
+	if msg.Fields["foo"].GetStringValue() != "bar" {
+		t.Errorf("decoded value wrong")
+	}
+	if err := decodeRequestBody(nil, msg); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBuildProxyResponse(t *testing.T) {
+	msg := &structpb.Struct{Fields: map[string]*structpb.Value{"a": structpb.NewStringValue("b")}}
+	resp, err := buildProxyResponse(msg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Data["a"].(string) != "b" {
+		t.Errorf("wrong data")
+	}
+	if resp.Metadata.Headers["Content-Type"][0] != "application/json" {
+		t.Errorf("wrong header")
+	}
+}
+
+func TestMergeParams(t *testing.T) {
+	path := map[string]string{"ID": "1"}
+	query := map[string][]string{"id": {"2"}}
+	out := mergeParams(path, query)
+	if len(out["id"]) != 2 {
+		t.Errorf("expected merged slice")
+	}
+}
+
+func TestParseServiceMethod(t *testing.T) {
+	svc, m, err := parseServiceMethod("svc/Method")
+	if err != nil || svc != "svc" || m != "Method" {
+		t.Errorf("unexpected result %s %s %v", svc, m, err)
+	}
+	if _, _, err := parseServiceMethod("bad"); err == nil {
+		t.Errorf("expected error")
+	}
+}

--- a/internal/router/provider_test.go
+++ b/internal/router/provider_test.go
@@ -1,0 +1,103 @@
+package router
+
+import (
+	"flag"
+	"os"
+	"testing"
+
+	"gateway/internal/config"
+	"github.com/gin-gonic/gin"
+	luraConfig "github.com/luraproject/lura/v2/config"
+	"github.com/luraproject/lura/v2/logging"
+	"github.com/luraproject/lura/v2/proxy"
+)
+
+func TestProvideServiceConfig(t *testing.T) {
+	tmp, err := os.CreateTemp(t.TempDir(), "cfg*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := `{"version":3,"name":"test","port":1234,"host":["http://localhost"],"endpoints":[]}`
+	if _, err := tmp.WriteString(data); err != nil {
+		t.Fatal(err)
+	}
+	tmp.Close()
+
+	oldArgs := os.Args
+	oldFS := flag.CommandLine
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+	os.Args = []string{"cmd", "-c", tmp.Name()}
+
+	cfg := &config.Config{}
+	svcCfg, err := ProvideServiceConfig(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if svcCfg.Port != 1234 {
+		t.Errorf("expected 1234 got %d", svcCfg.Port)
+	}
+
+	flag.CommandLine = oldFS
+	os.Args = oldArgs
+}
+
+func TestProvideServiceConfigOverride(t *testing.T) {
+	tmp, err := os.CreateTemp(t.TempDir(), "cfg*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := `{"version":3,"name":"test","port":1234,"host":["http://localhost"],"endpoints":[]}`
+	if _, err := tmp.WriteString(data); err != nil {
+		t.Fatal(err)
+	}
+	tmp.Close()
+
+	oldArgs := os.Args
+	oldFS := flag.CommandLine
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+	os.Args = []string{"cmd", "-c", tmp.Name(), "-p", "9999"}
+
+	cfg := &config.Config{}
+	svcCfg, err := ProvideServiceConfig(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if svcCfg.Port != 9999 {
+		t.Errorf("expected 9999 got %d", svcCfg.Port)
+	}
+
+	flag.CommandLine = oldFS
+	os.Args = oldArgs
+}
+
+func TestProvideGinRouter(t *testing.T) {
+	logger := logging.NoOp
+	svcCfg := &luraConfig.ServiceConfig{Port: 1234}
+	engine := ProvideGinRouter(logger, svcCfg, &config.Config{})
+	if len(engine.Handlers) != 3 {
+		t.Errorf("expected default handlers 3 got %d", len(engine.Handlers))
+	}
+
+	cfg := &config.Config{Sentry: config.SentryConfig{Enable: true}, Cluster: "c"}
+	engine = ProvideGinRouter(logger, svcCfg, cfg)
+	if len(engine.Handlers) != 5 {
+		t.Errorf("expected 5 handlers with sentry, got %d", len(engine.Handlers))
+	}
+}
+
+func TestProvideRouter(t *testing.T) {
+	logger := logging.NoOp
+	pf := proxyFactoryMock{}
+	eng := gin.New()
+	cfg := &config.Config{}
+	r := ProvideRouter(logger, pf, cfg, eng)
+	if r == nil {
+		t.Fatal("nil router")
+	}
+}
+
+type proxyFactoryMock struct{}
+
+func (proxyFactoryMock) New(*luraConfig.EndpointConfig) (proxy.Proxy, error) {
+	return proxy.NoopProxy, nil
+}

--- a/utils/error_methods_test.go
+++ b/utils/error_methods_test.go
@@ -1,0 +1,16 @@
+package utils
+
+import "testing"
+
+func TestHTTPResponseErrorMethods(t *testing.T) {
+	errObj := HTTPResponseError{Code: 404, Msg: "not found", HTTPEncoding: "app"}
+	if errObj.Error() != "not found" {
+		t.Errorf("Error() = %s", errObj.Error())
+	}
+	if errObj.StatusCode() != 404 {
+		t.Errorf("StatusCode() = %d", errObj.StatusCode())
+	}
+	if errObj.Encoding() != "app" {
+		t.Errorf("Encoding() = %s", errObj.Encoding())
+	}
+}


### PR DESCRIPTION
## Summary
- add tests for HTTPResponseError methods
- test HTTP client version parsing
- test router provider helpers
- test gRPC helper utilities

## Testing
- `go test ./... -coverprofile=coverage.out`
- `go tool cover -func=coverage.out | tail -n 1`

------
https://chatgpt.com/codex/tasks/task_e_684bd7ecf8cc8323ba46faaebce27121